### PR TITLE
improve library api

### DIFF
--- a/app/src/main/java/com/worker8/autoadapter/MultipleViewTypeActivity.kt
+++ b/app/src/main/java/com/worker8/autoadapter/MultipleViewTypeActivity.kt
@@ -69,7 +69,6 @@ class MultipleViewTypeActivity : AppCompatActivity() {
         adapter.submitList(list)
 
         state.setObserver {
-            Log.d("ddw", "here 1");
             adapter.submitList(it)
         }
 

--- a/app/src/main/java/com/worker8/autoadapter/ParallaxActivity.kt
+++ b/app/src/main/java/com/worker8/autoadapter/ParallaxActivity.kt
@@ -85,7 +85,8 @@ class ParallaxActivity : AppCompatActivity() {
 }
 
 private class ParallaxHeaderRow(override val data: HeaderAutoData) :
-    BaseRow<ParallaxHeaderRow.HeaderAutoData>(data, R.layout.parallax_header_row) {
+    BaseRow<ParallaxHeaderRow.HeaderAutoData>() {
+    override val layoutResId = R.layout.parallax_header_row
     override fun bind(itemView: View) {
         itemView.apply {
             parallaxTagText.text = data.tag
@@ -102,7 +103,8 @@ private class ParallaxHeaderRow(override val data: HeaderAutoData) :
 }
 
 private class ParallaxContentRow(override val data: StringData) :
-    BaseRow<StringData>(data, R.layout.parallax_content_row) {
+    BaseRow<StringData>() {
+    override val layoutResId = R.layout.parallax_content_row
     override fun bind(itemView: View) {
         itemView.apply {
             parallaxContentText.text = data.text

--- a/app/src/main/java/com/worker8/autoadapter/SimpleActivity.kt
+++ b/app/src/main/java/com/worker8/autoadapter/SimpleActivity.kt
@@ -38,8 +38,9 @@ class SimpleActivity : AppCompatActivity() {
     }
 }
 
-class NormalRow(override val data: NormalAutoData) :
-    BaseRow<NormalAutoData>(data, R.layout.normal_row) {
+private class NormalRow(override val data: NormalAutoData) :
+    BaseRow<NormalAutoData>() {
+    override val layoutResId = R.layout.normal_row
     override fun bind(itemView: View) {
         itemView.titleText.text = data.name
         itemView.descText.text = data.desc

--- a/app/src/main/java/com/worker8/autoadapter/rows/Column.kt
+++ b/app/src/main/java/com/worker8/autoadapter/rows/Column.kt
@@ -8,7 +8,8 @@ import com.worker8.autoadapter.data.ImageData
 import kotlinx.android.synthetic.main.horizontal_item.view.*
 
 class Column(override val data: ImageData) :
-    BaseRow<ImageData>(data, R.layout.horizontal_item) {
+    BaseRow<ImageData>() {
+    override val layoutResId = R.layout.horizontal_item
     override fun bind(itemView: View) {
         itemView.apply {
             itemText.text = data.text

--- a/app/src/main/java/com/worker8/autoadapter/rows/FooterRow.kt
+++ b/app/src/main/java/com/worker8/autoadapter/rows/FooterRow.kt
@@ -7,7 +7,9 @@ import com.worker8.autoadapter.R
 import kotlinx.android.synthetic.main.footer_row.view.*
 
 class FooterRow(private val privacyMessage: String) :
-    BaseRow<NoAutoData>(NoAutoData(), R.layout.footer_row) {
+    BaseRow<NoAutoData>() {
+    override val data = NoAutoData()
+    override val layoutResId = R.layout.footer_row
     override fun bind(itemView: View) {
         itemView.footerText.text = privacyMessage
     }

--- a/app/src/main/java/com/worker8/autoadapter/rows/HeaderRow.kt
+++ b/app/src/main/java/com/worker8/autoadapter/rows/HeaderRow.kt
@@ -7,7 +7,9 @@ import com.worker8.autoadapter.R
 import kotlinx.android.synthetic.main.header_row.view.*
 
 class HeaderRow(private val title: String) :
-    BaseRow<NoAutoData>(NoAutoData(), R.layout.header_row) {
+    BaseRow<NoAutoData>() {
+    override val layoutResId = R.layout.header_row
+    override val data = NoAutoData()
     override fun bind(itemView: View) {
         itemView.headerText.text = title
     }

--- a/app/src/main/java/com/worker8/autoadapter/rows/HorizontalListRow.kt
+++ b/app/src/main/java/com/worker8/autoadapter/rows/HorizontalListRow.kt
@@ -7,7 +7,8 @@ import com.worker8.autoadapter.R
 import kotlinx.android.synthetic.main.horizontal_list.view.*
 
 class HorizontalListRow(override val data: ColumnList) :
-    BaseRow<ColumnList>(data, R.layout.horizontal_list) {
+    BaseRow<ColumnList>() {
+    override val layoutResId = R.layout.horizontal_list
     override fun bind(itemView: View) {
         val adapter = AutoAdapter()
         itemView.horizontalRecyclerView.adapter = adapter

--- a/app/src/main/java/com/worker8/autoadapter/rows/ImageRow.kt
+++ b/app/src/main/java/com/worker8/autoadapter/rows/ImageRow.kt
@@ -7,8 +7,10 @@ import com.worker8.auto.adapter.library.NoAutoData
 import com.worker8.autoadapter.R
 import kotlinx.android.synthetic.main.image_row.view.*
 
-class ImageRow() :
-    BaseRow<NoAutoData>(NoAutoData(), R.layout.image_row) {
+class ImageRow:
+    BaseRow<NoAutoData>() {
+    override val data = NoAutoData()
+    override val layoutResId = R.layout.image_row
     override fun bind(itemView: View) {
         Glide.with(itemView.context)
             .load("https://i.imgur.com/55cN4iAh.png")

--- a/app/src/main/java/com/worker8/autoadapter/rows/NormalRow.kt
+++ b/app/src/main/java/com/worker8/autoadapter/rows/NormalRow.kt
@@ -7,7 +7,8 @@ import com.worker8.autoadapter.R
 import kotlinx.android.synthetic.main.normal_row.view.*
 
 class NormalRow(override val data: NormalAutoData) :
-    BaseRow<NormalAutoData>(data, R.layout.normal_row) {
+    BaseRow<NormalAutoData>() {
+    override val layoutResId = R.layout.normal_row
     override fun bind(itemView: View) {
         itemView.titleText.text = data.name
         itemView.descText.text = data.desc

--- a/app/src/main/java/com/worker8/autoadapter/rows/SimpleRow.kt
+++ b/app/src/main/java/com/worker8/autoadapter/rows/SimpleRow.kt
@@ -6,8 +6,11 @@ import com.worker8.autoadapter.R
 import com.worker8.autoadapter.data.StringData
 import kotlinx.android.synthetic.main.simple_row.view.*
 
-class SimpleRow(override val data: StringData, val onClick: () -> Unit) :
-    BaseRow<StringData>(data, R.layout.simple_row) {
+class SimpleRow(
+    override val data: StringData,
+    val onClick: () -> Unit
+) : BaseRow<StringData>() {
+    override val layoutResId = R.layout.simple_row
     override fun bind(itemView: View) {
         itemView.apply {
             simpleText.text = data.text

--- a/library/src/main/java/com/worker8/auto/adapter/library/BaseRow.kt
+++ b/library/src/main/java/com/worker8/auto/adapter/library/BaseRow.kt
@@ -3,6 +3,10 @@ package com.worker8.auto.adapter.library
 import android.view.View
 import androidx.annotation.LayoutRes
 
-abstract class BaseRow<AutoData>(open val data: AutoData, @LayoutRes val layoutResId: Int) {
+abstract class BaseRow<out T : AutoData> {
+    abstract val data: T
+
+    @get:LayoutRes
+    abstract val layoutResId: Int
     abstract fun bind(itemView: View)
 }

--- a/library/src/main/java/com/worker8/auto/adapter/library/SingleBaseRow.kt
+++ b/library/src/main/java/com/worker8/auto/adapter/library/SingleBaseRow.kt
@@ -1,6 +1,0 @@
-package com.worker8.auto.adapter.library
-
-import com.worker8.auto.adapter.library.BaseRow
-import com.worker8.auto.adapter.library.NoAutoData
-
-abstract class SingleBaseRow(layoutResId: Int) : BaseRow<NoAutoData>(NoAutoData(0), layoutResId)


### PR DESCRIPTION
`BaseRow` is a little hard to understand how to be used.

Changing `BaseRow` from this:

```
abstract class BaseRow<AutoData>(open val data: AutoData, @LayoutRes val layoutResId: Int) {
    abstract fun bind(itemView: View)
}
```

into this:

```
abstract class BaseRow<out T : AutoData> {
    abstract val data: T
    @get:LayoutRes
    abstract val layoutResId: Int
    abstract fun bind(itemView: View)
}
```

The user side will change too.

from:

```
class NormalRow(_data: NormalAutoData) :
    BaseRow<NormalAutoData>(_data, R.layout.normal_row) {
    override fun bind(itemView: View) {
        itemView.titleText.text = data.name
        itemView.descText.text = data.desc
    }
}
```

to 

```
class NormalRow(override val data: NormalAutoData) :
    BaseRow<NormalAutoData>() {
    override val layoutResId = R.layout.normal_row
    override fun bind(itemView: View) {
        itemView.titleText.text = data.name
        itemView.descText.text = data.desc
    }
}
```

### Purpose
This is to make the purpose more explicit that in order to use a `BaseRow`, we have to override 2 fields and 1 method. Each row will take care of how it should look(layoutResId) and how it should behave (the `bind` method), using the `data` object.

